### PR TITLE
Changed phpspec code coverage dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,7 @@
     },
     "require-dev": {
         "bossa/phpspec2-expect": "~2.0",
-        "henrikbjorn/phpspec-code-coverage": "dev-master",
-        "phpunit/php-code-coverage": "^5.0|^4.0",
+        "leanphp/phpspec-code-coverage": "~3.0",
         "pedrotroller/php-cs-custom-fixer": "~1.4.0",
         "phpspec/phpspec": "~3.0",
         "phpspec/prophecy": "~1.6"

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,7 +1,7 @@
 formatter.name: pretty
 
 extensions:
-    PhpSpecCodeCoverage\CodeCoverageExtension: ~
+    LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension: ~
 
 code_coverage:
     format:


### PR DESCRIPTION
The new one is a fork maintained. It will be easy to upgrade to new versions of PHPSpec as soon as we drop support for PHP 5.6.