### PR TITLE
Implement dump command for dictionaries, #6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `knp:dictionary:dump` command for dictionary listing and preview
 
 ## [2.0.1] - 2017-12-15
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,20 @@ App\Entity\User:
         city: <dictionary('cities')>
 ```
 
+## Use dictionary command
+
+You can use the following command to show your app dictionaries easily:
+```bash
+php app/console knp:dictionary:dump # SF2
+php bin/console knp:dictionary:dump # SF3 / SF4 
+```
+
+If you want to display only one dictionary, you can set it name in argument
+```bash
+php app/console knp:dictionary:dump my_dictionary # SF2
+php bin/console knp:dictionary:dump my_dictionary # SF3 / SF4 
+```
+
 ## Create your own dictionary implementation
 
 ### Dictionary

--- a/src/Knp/DictionaryBundle/Command/DictionaryDumpCommand.php
+++ b/src/Knp/DictionaryBundle/Command/DictionaryDumpCommand.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Knp\DictionaryBundle\Command;
+
+use Knp\DictionaryBundle\Dictionary;
+use Knp\DictionaryBundle\Dictionary\DictionaryRegistry;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Dump dictionaries with their related values
+ */
+class DictionaryDumpCommand extends ContainerAwareCommand
+{
+    protected static $defaultName = 'knp:dictionary:dump';
+
+    /**
+     * @var DictionaryRegistry $registry
+     */
+    private $registry;
+
+    public function __construct(DictionaryRegistry $registry)
+    {
+        parent::__construct();
+        $this->registry = $registry;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Dump KNP Dictionnaries')
+            ->setHelp('This command allows you to dump KNP dictionnaries and their values')
+            ->addArgument(
+                'dictionary',
+                InputArgument::OPTIONAL,
+                'Dictionary name you want to display'
+            )
+            ->setHelp(<<<'EOF'
+The <info>%command.name%</info> list all dictionaries with their related values.
+You can choose to list a specific dictionary:
+
+  <info>php %command.full_name% your_dictionary_name</info>
+EOF
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $dictionaryName = $input->getArgument('dictionary');
+        $io = new SymfonyStyle($input, $output);
+        $errorIo = $io->getErrorStyle();
+
+        // Add output context text
+        $io->title('KNP Dictionary');
+        $io->text('Here is the KNP Directory with their related values');
+        if (!\is_null($dictionaryName)) {
+            $io->text("Search for dictionary named <fg=green>$dictionaryName</fg=green>");
+        }
+        $io->newLine();
+
+        // Read dictionaries information
+        $tableRows = $this->getDictionariesDetail($dictionaryName);
+
+        // Output data
+        if (sizeof($tableRows) > 0) {
+            $io->table([], $tableRows);
+        } elseif (!\is_null($dictionaryName) && 0 === sizeof($tableRows)) {
+            $errorIo->error("No dictionary named $dictionaryName");
+        }
+    }
+
+    /**
+     * Get all dictionaries with they values
+     * If $dictionaryName is set, only display dictionary matching dictionary
+     *
+     * @param null|string $dictionaryName the dictionary name asked for filtering
+     * @return array rows to display
+     */
+    private function getDictionariesDetail($dictionaryName = null)
+    {
+        $tableRows = [];
+        /** @var Dictionary $dico */
+        foreach ($this->registry->all() as $dico) {
+            if (!\is_null($dictionaryName) && $dictionaryName === $dico->getName() || \is_null($dictionaryName)) {
+                $tableRows[] = ["<fg=cyan>{$dico->getName()}</fg=cyan>"];
+                foreach ($dico->getValues() as $value) {
+                    $tableRows[] = ["   $value"];
+                }
+            }
+        }
+
+        return $tableRows;
+    }
+}

--- a/src/Knp/DictionaryBundle/Command/DictionaryDumpCommand.php
+++ b/src/Knp/DictionaryBundle/Command/DictionaryDumpCommand.php
@@ -4,7 +4,7 @@ namespace Knp\DictionaryBundle\Command;
 
 use Knp\DictionaryBundle\Dictionary;
 use Knp\DictionaryBundle\Dictionary\DictionaryRegistry;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * Dump dictionaries with their related values
  */
-class DictionaryDumpCommand extends ContainerAwareCommand
+class DictionaryDumpCommand extends Command
 {
     protected static $defaultName = 'knp:dictionary:dump';
 
@@ -31,14 +31,14 @@ class DictionaryDumpCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this
-            ->setDescription('Dump KNP Dictionnaries')
+            ->setDescription('Dump Dictionaries')
             ->setHelp('This command allows you to dump KNP dictionnaries and their values')
             ->addArgument(
                 'dictionary',
                 InputArgument::OPTIONAL,
                 'Dictionary name you want to display'
             )
-            ->setHelp(<<<'EOF'
+            ->setHelp(<<<EOF
 The <info>%command.name%</info> list all dictionaries with their related values.
 You can choose to list a specific dictionary:
 
@@ -56,7 +56,7 @@ EOF
 
         // Add output context text
         $io->title('KNP Dictionary');
-        $io->text('Here is the KNP Directory with their related values');
+        $io->text('Here are the dictionaries with their related key-values:');
         if (!\is_null($dictionaryName)) {
             $io->text("Search for dictionary named <fg=green>$dictionaryName</fg=green>");
         }
@@ -66,9 +66,9 @@ EOF
         $tableRows = $this->getDictionariesDetail($dictionaryName);
 
         // Output data
-        if (sizeof($tableRows) > 0) {
+        if (\sizeof($tableRows) > 0) {
             $io->table([], $tableRows);
-        } elseif (!\is_null($dictionaryName) && 0 === sizeof($tableRows)) {
+        } elseif (!\is_null($dictionaryName) && 0 === \sizeof($tableRows)) {
             $errorIo->error("No dictionary named $dictionaryName");
         }
     }
@@ -87,8 +87,8 @@ EOF
         foreach ($this->registry->all() as $dico) {
             if (!\is_null($dictionaryName) && $dictionaryName === $dico->getName() || \is_null($dictionaryName)) {
                 $tableRows[] = ["<fg=cyan>{$dico->getName()}</fg=cyan>"];
-                foreach ($dico->getValues() as $value) {
-                    $tableRows[] = ["   $value"];
+                foreach ($dico as $key => $value) {
+                    $tableRows[] = ["   $key\t| $value"];
                 }
             }
         }

--- a/src/Knp/DictionaryBundle/Resources/config/dictionary.xml
+++ b/src/Knp/DictionaryBundle/Resources/config/dictionary.xml
@@ -57,5 +57,10 @@
     </service>
 
     <service id="knp_dictionary.registry" alias="knp_dictionary.dictionary.dictionary_registry"/>
+
+    <service id="knp_dictionary.command.dictionary_dump" class="Knp\DictionaryBundle\Command\DictionaryDumpCommand">
+      <argument type="service" id="knp_dictionary.registry"/>
+      <tag name="console.command" command="knp:dictionary:dump" />
+    </service>
   </services>
 </container>


### PR DESCRIPTION
This PR is related to issue #6.    
This PR creates command `knp:dictionary:dump`which output all directories. Here is an example in SF 3 or 4:
```yaml
# app/config/config.yml
knp_dictionary:
    dictionaries:
        dictionary1:
            - Foo1
            - Bar1
            - Baz1
        dictionary2:
            - Foo2
            - Bar2
            - Baz2
```

`php bin/console knp:dictionary:dump` will output all dictionaries
```bash

KNP Dictionary
==============

 Here is the KNP Directory with their related values

 -------------
  dictionary1
     Foo1
     Bar1
     Baz1
  dictionary2
     Foo2
     Bar2
     Baz2
 -------------
```

`php bin/console knp:dictionary:dump directory1` will output directory1 values
```bash

KNP Dictionary
==============

 Here is the KNP Directory with their related values
 Search for dictionary named dictionary1

 -------------
  dictionary1
     Foo1
     Bar1
     Baz1
 -------------
```