### PR TITLE
Upgrade PHP 7.1 + upgrade dependencies, #21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
     - 7.1
     - 7.2
+    - nightly
 
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-    - 5.6
-    - 7.0
     - 7.1
     - 7.2
 
@@ -12,11 +10,9 @@ cache:
 
 matrix:
     include:
-        - php: 5.6
-          env: 'COMPOSER_FLAGS="--prefer-lowest --prefer-stable"'
-        - php: 7.0
-          env: 'COMPOSER_FLAGS="--prefer-lowest --prefer-stable"'
         - php: 7.1
+          env: 'COMPOSER_FLAGS="--prefer-lowest --prefer-stable"'
+        - php: 7.2
           env: 'COMPOSER_FLAGS="--prefer-lowest --prefer-stable"'
 
 branches:
@@ -24,6 +20,7 @@ branches:
         - master
         - 1.x
         - 2.x
+        - 3.x
 
 before_script:
     - composer update --prefer-source $COMPOSER_FLAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 php:
     - 7.1
     - 7.2
-    - nightly
 
 cache:
     directories:
@@ -15,13 +14,16 @@ matrix:
           env: 'COMPOSER_FLAGS="--prefer-lowest --prefer-stable"'
         - php: 7.2
           env: 'COMPOSER_FLAGS="--prefer-lowest --prefer-stable"'
+        - php: nightly
+          env: 'COMPOSER_FLAGS="--ignore-platform-reqs"'
+    allow_failures:
+        - php: nightly
 
 branches:
     only:
         - master
         - 1.x
         - 2.x
-        - 3.x
 
 before_script:
     - composer update --prefer-source $COMPOSER_FLAGS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Upgrade `php-cs-fixer` package from `^1.11` to `^2.2` && update `.php_cs` rules
-- PHP 5.6 is now the minimum version requirement
+- PHP 7.1 is now the minimum version requirement
 - Add composer package in Dockerfile
 
 ## [2.1.2] - 2018-02-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Upgrade `php-cs-fixer` package from `^1.11` to `^2.2` && update `.php_cs` rules
+- Upgrade `php-cs-fixer` package from `^1.11` to `^2.11` && update `.php_cs` rules
 - PHP 7.1 is now the minimum version requirement
 - Add composer package in Dockerfile
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ $bundles = array(
 You can ping us if you need some reviews/comments/help:
 
  - [@Nek-](https://github.com/Nek-)
+ - [@Awkan](https://github.com/Awkan)
  - [@babeou](https://github.com/babeou)
 
 ## Basic usage
-Define dictionaries in your config.yml file:
+Define dictionaries in your config.yaml file:
 ```yaml
 knp_dictionary:
     dictionaries:
@@ -84,11 +85,6 @@ public function buildForm(FormBuilderInterface $builder, array $options)
 {
     $builder
         ->add('civility', DictionaryType::class, [
-            'name' => 'my_dictionary'
-        ])
-
-        // Symfony 2.x syntax
-        ->add('civility', 'dictionary', [
             'name' => 'my_dictionary'
         ])
     ;
@@ -208,14 +204,12 @@ App\Entity\User:
 
 You can use the following command to show your app dictionaries easily:
 ```bash
-php app/console knp:dictionary:dump # SF2
-php bin/console knp:dictionary:dump # SF3 / SF4 
+php bin/console knp:dictionary:dump
 ```
 
 If you want to display only one dictionary, you can set it name in argument
 ```bash
-php app/console knp:dictionary:dump my_dictionary # SF2
-php bin/console knp:dictionary:dump my_dictionary # SF3 / SF4 
+php bin/console knp:dictionary:dump my_dictionary
 ```
 
 ## Create your own dictionary implementation
@@ -224,8 +218,6 @@ php bin/console knp:dictionary:dump my_dictionary # SF3 / SF4
 Your dictionary implementation must implements the interface [Dictionary](src/Knp/DictionaryBundle/Dictionary/Dictionary.php).
 In Symfony >= 3.3, your class will be automatically register as dictionary service.
 
-For older Symfony versions (2.8 - 3.2) you need to add the tag `knp_dictionary.dictionary`.
-
 ### Dictionary Factory
 You must create a dictionary factory that will be responsible to instanciate your dictionary.
 
@@ -233,12 +225,6 @@ You must create a dictionary factory that will be responsible to instanciate you
 services:
     # Syntax Symfony >= 3.3
     App\Dictionary\Factory\MyCustomFactory:
-        tags:
-            { name: 'knp_dictionary.factory' }
-            
-    # Syntax Symfony < 3.3
-    app.dictionary.factory.my_custom_factory:
-        class: App\Dictionary\Factory\MyCustomFactory
         tags:
             { name: 'knp_dictionary.factory' }
 ```

--- a/composer.json
+++ b/composer.json
@@ -24,22 +24,22 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^5.6 || >=7.0",
-        "symfony/http-kernel": "~2.8 || ~3.0 || ~4.0",
-        "symfony/dependency-injection": "~2.8 || ~3.0 || ~4.0",
-        "symfony/http-foundation": "~2.8 || ~3.0 || ~4.0",
-        "symfony/config": "~2.8 || ~3.0 || ~4.0",
-        "symfony/form": "~2.8 || ~3.0 || ~4.0",
-        "symfony/validator": "~2.8 || ~3.0 || ~4.0",
-        "twig/twig": "~1.12|~2.0",
-        "fzaninotto/faker": "^1.5"
+        "php": "^7.1",
+        "symfony/http-kernel": "^3.4 || ^4.0",
+        "symfony/dependency-injection": "^3.4 || ^4.0",
+        "symfony/http-foundation": "^3.4 || ^4.0",
+        "symfony/config": "^3.4 || ^4.0",
+        "symfony/form": "^3.4 || ^4.0",
+        "symfony/validator": "^3.4 || ^4.0",
+        "twig/twig": "^2.0",
+        "fzaninotto/faker": "^1.6"
     },
     "require-dev": {
-        "bossa/phpspec2-expect": "~2.0",
-        "friendsofphp/php-cs-fixer": "^2.2",
-        "leanphp/phpspec-code-coverage": "~3.0",
-        "phpspec/phpspec": "~3.0",
-        "phpspec/prophecy": "~1.6"
+        "bossa/phpspec2-expect": "^3.0",
+        "friendsofphp/php-cs-fixer": "^2.11",
+        "leanphp/phpspec-code-coverage": "^4.0",
+        "phpspec/phpspec": "^4.0",
+        "phpspec/prophecy": "^1.7"
     },
     "config": {
         "bin-dir": "bin"

--- a/composer.json
+++ b/composer.json
@@ -38,8 +38,10 @@
         "bossa/phpspec2-expect": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.11",
         "leanphp/phpspec-code-coverage": "^4.0",
+        "phpunit/php-code-coverage": "^5.2.3",
         "phpspec/phpspec": "^4.0",
-        "phpspec/prophecy": "^1.7"
+        "phpspec/prophecy": "^1.7",
+        "sebastian/comparator": "^2.0"
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
#21 

- Remove PHP 5.6 utilisisability in favor of PHP7.1
- Upgrade dependencies (newer + explicitly compatible with PHP7+)
- Remove compatibility with SF2 (minimum requirement is now SF 3.4+)
- Update Travis config