### PR TITLE
Add possibility to get the original dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add new method `getOriginalDictionary` on TraceableDictionary
+
 ### Changed
 - Upgrade `php-cs-fixer` package from `^1.11` to `^2.11` && update `.php_cs` rules
 - PHP 7.1 is now the minimum version requirement

--- a/spec/Knp/DictionaryBundle/Dictionary/TraceableDictionarySpec.php
+++ b/spec/Knp/DictionaryBundle/Dictionary/TraceableDictionarySpec.php
@@ -3,6 +3,7 @@
 namespace spec\Knp\DictionaryBundle\Dictionary;
 
 use Knp\DictionaryBundle\DataCollector\DictionaryDataCollector;
+use Knp\DictionaryBundle\Dictionary;
 use Knp\DictionaryBundle\Dictionary\SimpleDictionary;
 use PhpSpec\ObjectBehavior;
 
@@ -80,5 +81,10 @@ class TraceableDictionarySpec extends ObjectBehavior
         $collector->addDictionary('name', ['foo', 'baz'], ['bar', null])->shouldbeCalled();
 
         expect(\iterator_to_array($this->getIterator()->getWrappedObject()))->toBe(['foo' => 'bar', 'baz' => null]);
+    }
+
+    public function it_gives_back_dictionary()
+    {
+        $this->getOriginalDictionary()->shouldBeAnInstanceOf(Dictionary::class);
     }
 }

--- a/src/Knp/DictionaryBundle/Dictionary/TraceableDictionary.php
+++ b/src/Knp/DictionaryBundle/Dictionary/TraceableDictionary.php
@@ -104,6 +104,14 @@ class TraceableDictionary implements Dictionary
     }
 
     /**
+     * @return Dictionary
+     */
+    public function getOriginalDictionary(): Dictionary
+    {
+        return $this->dictionary;
+    }
+
+    /**
      * Register this dictioanry as used.
      */
     private function trace()


### PR DESCRIPTION
Fix #20

On development environments, the dictionary is replaced by a traceable one.
This method adds the possibility to retrieve the original dictionary.