### PR TITLE
Fix name command empty

### DIFF
--- a/src/Knp/DictionaryBundle/Command/DictionaryDumpCommand.php
+++ b/src/Knp/DictionaryBundle/Command/DictionaryDumpCommand.php
@@ -31,6 +31,7 @@ class DictionaryDumpCommand extends Command
     protected function configure()
     {
         $this
+            ->setName(self::$defaultName)
             ->setDescription('Dump Dictionaries')
             ->setHelp('This command allows you to dump KNP dictionnaries and their values')
             ->addArgument(


### PR DESCRIPTION
Add ``->setName(self::$defaultName)`` because command cannot have an empty name