### PR TITLE
Allow to use validator inside another annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.1.5] - 2019-09-27
+### Changed
+- Allow to use the validator inside another annotation
+
 ## [2.1.4] - 2019-03-29
 ### Changed
 - Fix deprecation trigger of Sf 4.2

--- a/src/Knp/DictionaryBundle/Validator/Constraints/Dictionary.php
+++ b/src/Knp/DictionaryBundle/Validator/Constraints/Dictionary.php
@@ -6,7 +6,7 @@ use Symfony\Component\Validator\Constraint;
 
 /**
  * @Annotation
- * @Target({"PROPERTY", "METHOD"})
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  */
 class Dictionary extends Constraint
 {


### PR DESCRIPTION
This fix will allow us to use it inside an `@All()` annotation of [Symfony validator](https://symfony.com/doc/current/reference/constraints/All.html).