### PR TITLE
DictionaryValidator containing zero value never add constraint violation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Fixed
 - Dump command works with category dictionaries
+- DictionaryValidator now add violation to context for dictionaries containing (int) 0 value. It wasn't the case before
 
 ## [3.0.0-alpha1] - 2018-07-06
 ### Added

--- a/spec/Knp/DictionaryBundle/Validator/Constraints/DictionaryValidatorSpec.php
+++ b/spec/Knp/DictionaryBundle/Validator/Constraints/DictionaryValidatorSpec.php
@@ -46,6 +46,20 @@ class DictionaryValidatorSpec extends ObjectBehavior
         $this->validate('the_unexisting_key', $constraint);
     }
 
+    public function it_adds_violation_string_value_with_dictionary_containing_0(DictionaryRegistry $registry, ExecutionContextInterface $context, Dictionary $dictionary)
+    {
+        $this->initialize($context);
+
+        $registry->get('dico')->willReturn($dictionary);
+
+        $dictionary->getKeys()->willReturn([0, 1]);
+        $constraint = new Constraint(['name' => 'dico']);
+
+        $context->addViolation('The key(s) {{ key }} doesn\'t exist in the given dictionary. {{ keys }} available.', ['{{ key }}' => 'a not existing key', '{{ keys }}' => '0, 1'])->shouldBeCalled();
+
+        $this->validate('a not existing key', $constraint);
+    }
+
     public function it_throw_exception_form_unknown_constraints()
     {
         $constraint = new NotNull();

--- a/src/Knp/DictionaryBundle/Validator/Constraints/DictionaryValidator.php
+++ b/src/Knp/DictionaryBundle/Validator/Constraints/DictionaryValidator.php
@@ -47,7 +47,7 @@ class DictionaryValidator extends ConstraintValidator
                     ['{{ key }}' => \implode(', ', $wrongValues), '{{ keys }}' => \implode(', ', $values)]
                 );
             }
-        } elseif (false === \in_array($value, $values)) {
+        } elseif (false === \in_array($value, $values, true)) {
             $this->context->addViolation(
                 $constraint->message,
                 ['{{ key }}' => $value, '{{ keys }}' => \implode(', ', $values)]


### PR DESCRIPTION
Because `in_array` performs the comparison with `==` operator if the third parameter (strict) isn't true.

```php 
0 == 'str' => true
```

So a dictionary with these values 

- 0
- 1
- 2
- 3

And value is given to the validator, for example `I'm a string`
The validator won't add a constraint violation